### PR TITLE
Fix 64-bit timestamp math in Awkward compiler

### DIFF
--- a/shared/src/main/scala/io/kaitai/struct/languages/AwkwardCompiler.scala
+++ b/shared/src/main/scala/io/kaitai/struct/languages/AwkwardCompiler.scala
@@ -1947,7 +1947,7 @@ object AwkwardCompiler extends LanguageCompilerStatic
       case BitsType(_, _) => "uint64_t"
 
       case _: BooleanType => "bool"
-      case CalcIntType => "int32_t"
+      case CalcIntType => "int64_t"
       case CalcFloatType => "double"
 
       case _: StrType => "std::string"

--- a/shared/src/main/scala/io/kaitai/struct/translators/AwkwardTranslator.scala
+++ b/shared/src/main/scala/io/kaitai/struct/translators/AwkwardTranslator.scala
@@ -123,6 +123,13 @@ class AwkwardTranslator(provider: TypeProvider, importListSrc: CppImportList, im
     (detectType(left), detectType(right), op) match {
       case (_: IntType, _: IntType, Ast.operator.Mod) =>
         s"${AwkwardCompiler.kstreamName}::mod(${translate(left)}, ${translate(right)})"
+      case (_: IntType, _: IntType, Ast.operator.LShift) =>
+        right match {
+          case Ast.expr.IntNum(n) if n >= 32 =>
+            s"(static_cast<uint64_t>(${translate(left)}) << ${translate(right)})"
+          case _ =>
+            super.numericBinOp(left, op, right)
+        }
       case _ =>
         super.numericBinOp(left, op, right)
     }


### PR DESCRIPTION
## Summary
- force 64-bit integer math for value-instance shifts >= 32
- avoid undefined behavior in generated timestamp_full expressions

## Testing
- not run in this repo (validated via parent repo: make test)